### PR TITLE
Remove extraneous newline to fix apt-get update

### DIFF
--- a/controlplane/src/main.rs
+++ b/controlplane/src/main.rs
@@ -444,7 +444,6 @@ async fn generate_indexes(
             release_index.push_str(&format!("{}: {}\n", k, v));
         }
     }
-    release_index.push_str("\n");
 
     let indexes = sqlx::query!(r#"
         SELECT


### PR DESCRIPTION
In a RFC-822-type header file, a double newline marks the end of a header section. In particular, that’s [how APT parses release index files](https://salsa.debian.org/apt-team/apt/-/blob/ccd3b00975f96a62835e02cd243f624d47812b56/apt-pkg/tagfile.cc#L575-585
).

However, Attune adds an extra newline between the `Description` entry and the first hash entry, causing APT to ignore all hash entries and degrading all `apt-get update` invocations as follows:

```plain
Reading package lists... Done
W: No Hash entry in Release file /var/lib/apt/lists/partial/debian.eu-central-1.linodeobjects.com_dists_byzantium_InRelease
E: The repository 'https://debian.eu-central-1.linodeobjects.com byzantium InRelease' provides only weak security information.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

Excerpt from the Release file in question:

```plain
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA256

Origin: byzantium
Label: Claudia Pellegrino’s Debian archive
Suite: byzantium
Codename: byzantium
Date: Thu, 24 Apr 2025 23:33:49 +0000
Architectures:  all
Components:  main
Description: Generated by Attune

MD5Sum:
 ee638214693041fd8484510e072217c1  1406 main/binary-all/Packages
SHA256:
 944338bb259c374a1b9b0d7da42792f7ff75f3f0c31bb439f706494a2f7167aa  1406 main/binary-all/Packages
-----BEGIN PGP SIGNATURE-----
[…]
```

Note the extra newline between the `Description` and `MD5Sum` entries.

The issue is 100% reproducible on bookworm (PureOS Byzantium) running apt 2.2.4, and very likely on other distributions and suites.

This PR removes the extraneous newline to make APT pick up the hash entries, which fixes the `apt-get update` invocation, allowing it to run to completion without complaining about missing hashes.
