### PR TITLE
Accept signing key ID as alternative to key file

### DIFF
--- a/cli/cmd/attune/repository.go
+++ b/cli/cmd/attune/repository.go
@@ -6,14 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
-	"syscall"
 	"text/tabwriter"
 	"time"
 
-	"github.com/ProtonMail/gopenpgp/v3/crypto"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 func repoCmd() *cobra.Command {
@@ -39,12 +35,7 @@ func repoCmd() *cobra.Command {
 	statusRepositoryCmd.Flags().IntP("repo-id", "r", 0, "ID of the repository")
 	statusRepositoryCmd.MarkFlagRequired("repo-id")
 
-	syncRepositoryCmd.Flags().IntP("repo-id", "r", 0, "ID of the repository")
-	syncRepositoryCmd.MarkFlagRequired("repo-id")
-	syncRepositoryCmd.Flags().StringP("signing-key-file", "k", "", "File containing armored GPG private key for signing")
-	syncRepositoryCmd.MarkFlagRequired("signing-key-file")
-
-	cmd.AddCommand(createRepositoryCmd, listRepositoriesCmd, statusRepositoryCmd, syncRepositoryCmd, repoPkgCmd())
+	cmd.AddCommand(createRepositoryCmd, listRepositoriesCmd, statusRepositoryCmd, repoSyncCmd(), repoPkgCmd())
 	return cmd
 }
 
@@ -257,145 +248,3 @@ var statusRepositoryCmd = &cobra.Command{
 	},
 }
 
-type RepositoryIndexes struct {
-	Release string
-}
-
-type SyncRepositoryRequest struct {
-	Clearsigned string `json:"clearsigned"`
-	Detached    string `json:"detached"`
-}
-
-var syncRepositoryCmd = &cobra.Command{
-	// Other potential names: "commit", "deploy", "update", "push"?
-	Use:   "sync",
-	Short: "Synchronize unsaved changes to repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		repoID, err := cmd.Flags().GetInt("repo-id")
-		if err != nil {
-			fmt.Printf("could not read --repo-id: %s\n", err)
-			os.Exit(1)
-		}
-		signingKeyFile, err := cmd.Flags().GetString("signing-key-file")
-		if err != nil {
-			fmt.Printf("could not read --signing-key-file: %s\n", err)
-			os.Exit(1)
-		}
-
-		// Load release index for signing.
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/repositories/%d/indexes", repoID), nil)
-		if err != nil {
-			fmt.Printf("could not create request to get repository indexes: %s\n", err)
-			os.Exit(1)
-		}
-		res, err := API(req)
-		if err != nil {
-			fmt.Printf("could not get repository indexes: %s\n", err)
-			os.Exit(1)
-		}
-		defer res.Body.Close()
-
-		if res.StatusCode != http.StatusOK {
-			fmt.Printf("could not get repository indexes: %s\n", res.Status)
-			os.Exit(1)
-		}
-
-		var indexes RepositoryIndexes
-		if err := json.NewDecoder(res.Body).Decode(&indexes); err != nil {
-			fmt.Printf("could not decode repository indexes: %s\n", err)
-			os.Exit(1)
-		}
-
-		// Sign release index.
-		keyFd, err := os.Open(signingKeyFile)
-		if err != nil {
-			fmt.Printf("could not open key file: %s\n", err)
-			os.Exit(1)
-		}
-		defer keyFd.Close()
-
-		key, err := crypto.NewKeyFromReader(keyFd)
-		if err != nil {
-			fmt.Printf("could not parse key file: %s\n", err)
-			os.Exit(1)
-		}
-		locked, err := key.IsLocked()
-		if err != nil {
-			fmt.Printf("could not determine whether key is locked: %s\n", err)
-			os.Exit(1)
-		}
-		if locked {
-			fmt.Printf("Key is locked. Please enter passphrase: ")
-			var passphrase []byte
-			passphrase, err = term.ReadPassword(int(syscall.Stdin))
-			if err != nil {
-				fmt.Printf("could not read passphrase: %s\n", err)
-				os.Exit(1)
-			}
-			key, err = key.Unlock(passphrase)
-			if err != nil {
-				fmt.Printf("could not unlock key: %s\n", err)
-				os.Exit(1)
-			}
-			fmt.Println()
-		}
-
-		pgp := crypto.PGP()
-		signer, err := pgp.Sign().SigningKey(key).New()
-		if err != nil {
-			fmt.Printf("could not create signer: %s\n", err)
-			os.Exit(1)
-		}
-
-		// Notice the trimmed newline. This is apparently a long-standing
-		// compatibility bug in GPG cleartext signing. See:
-		// - https://lists.gnupg.org/pipermail/gnupg-devel/1999-September/016016.html
-		// - https://dev.gnupg.org/T7106
-		clearsigned, err := signer.SignCleartext([]byte(strings.TrimSuffix(indexes.Release, "\n")))
-		if err != nil {
-			fmt.Printf("could not clearsign release index: %s\n", err)
-			os.Exit(1)
-		}
-		detached, err := signer.Sign([]byte(indexes.Release), crypto.Armor)
-		if err != nil {
-			fmt.Printf("could not detached sign release index: %s\n", err)
-			os.Exit(1)
-		}
-
-		// Start synchronization.
-		reqBody := SyncRepositoryRequest{
-			Clearsigned: string(clearsigned),
-			Detached:    string(detached),
-		}
-
-		jsonBody, err := json.Marshal(reqBody)
-		if err != nil {
-			fmt.Printf("could not marshal SyncRepositoryRequest: %s\n", err)
-			os.Exit(1)
-		}
-
-		req, err = http.NewRequest(
-			http.MethodPost,
-			fmt.Sprintf("/api/v0/repositories/%d/sync", repoID),
-			bytes.NewReader(jsonBody),
-		)
-		if err != nil {
-			fmt.Printf("could not create request for starting synchronization: %s\n", err)
-			os.Exit(1)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		res, err = API(req)
-		if err != nil {
-			fmt.Printf("could not start synchronization: %s\n", err)
-			os.Exit(1)
-		}
-		defer res.Body.Close()
-
-		if res.StatusCode != http.StatusOK {
-			fmt.Printf("could not start synchronization: %s\n", res.Status)
-			os.Exit(1)
-		}
-
-		fmt.Println("Synchronization completed!")
-	},
-}

--- a/cli/cmd/attune/repository_sync.go
+++ b/cli/cmd/attune/repository_sync.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/ProtonMail/gopenpgp/v3/crypto"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+type RepositoryIndexes struct {
+	Release string
+}
+
+type SyncRepositoryRequest struct {
+	Clearsigned string `json:"clearsigned"`
+	Detached    string `json:"detached"`
+}
+
+func repoSyncCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		// Other potential names: "commit", "deploy", "update", "push"?
+		Use:   "sync",
+		Short: "Synchronize unsaved changes to repository",
+		Long: `Synchronize unsaved changes to repository.
+
+This command signs and publishes the repository's Release file using GPG. You must
+specify exactly one of the following signing methods:
+
+1. --signing-key-file=<path>: Provide a file containing an armored GPG private key.
+2. --signing-key-id=<key-id>: Use your local GPG installation with the specified key ID (fingerprint, email, etc.).
+
+When using local GPG (--signing-key-id), the command will invoke the system's gpg
+command to sign the Release file. This allows using keys stored in your local
+keyring, GPG agent, or hardware tokens.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			repoID, err := cmd.Flags().GetInt("repo-id")
+			if err != nil {
+				fmt.Printf("could not read --repo-id: %s\n", err)
+				os.Exit(1)
+			}
+
+			// Get signing method flags and make sure exactly one method is selected.
+			signingKeyFile, err := cmd.Flags().GetString("signing-key-file")
+			if err != nil {
+				fmt.Printf("could not read --signing-key-file: %s\n", err)
+				os.Exit(1)
+			}
+			signingKeyID, err := cmd.Flags().GetString("signing-key-id")
+			if err != nil {
+				fmt.Printf("could not read --signing-key-id: %s\n", err)
+				os.Exit(1)
+			}
+			if (signingKeyFile == "") == (signingKeyID == "") {
+				fmt.Println("Error: You must specify exactly one signing method:")
+				fmt.Println("  --signing-key-file=<path> OR --signing-key-id=<key-id>")
+				os.Exit(1)
+			}
+
+			// Load release index for signing.
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/repositories/%d/indexes", repoID), nil)
+			if err != nil {
+				fmt.Printf("could not create request to get repository indexes: %s\n", err)
+				os.Exit(1)
+			}
+			res, err := API(req)
+			if err != nil {
+				fmt.Printf("could not get repository indexes: %s\n", err)
+				os.Exit(1)
+			}
+			defer res.Body.Close()
+
+			if res.StatusCode != http.StatusOK {
+				fmt.Printf("could not get repository indexes: %s\n", res.Status)
+				os.Exit(1)
+			}
+
+			var indexes RepositoryIndexes
+			if err := json.NewDecoder(res.Body).Decode(&indexes); err != nil {
+				fmt.Printf("could not decode repository indexes: %s\n", err)
+				os.Exit(1)
+			}
+
+			var syncRequest *SyncRepositoryRequest
+			if signingKeyFile != "" {
+				// Sign release index using provided key file.
+				syncRequest, err = signWithKeyFile(signingKeyFile, indexes.Release)
+			} else {
+				// Sign release index using local GPG installation.
+				syncRequest, err = signWithLocalGPG(signingKeyID, indexes.Release)
+			}
+
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			// Start synchronization.
+			jsonBody, err := json.Marshal(syncRequest)
+			if err != nil {
+				fmt.Printf("could not marshal SyncRepositoryRequest: %s\n", err)
+				os.Exit(1)
+			}
+
+			req, err = http.NewRequest(
+				http.MethodPost,
+				fmt.Sprintf("/api/v0/repositories/%d/sync", repoID),
+				bytes.NewReader(jsonBody),
+			)
+			if err != nil {
+				fmt.Printf("could not create request for starting synchronization: %s\n", err)
+				os.Exit(1)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			res, err = API(req)
+			if err != nil {
+				fmt.Printf("could not start synchronization: %s\n", err)
+				os.Exit(1)
+			}
+			defer res.Body.Close()
+
+			if res.StatusCode != http.StatusOK {
+				fmt.Printf("could not start synchronization: %s\n", res.Status)
+				os.Exit(1)
+			}
+
+			fmt.Println("Synchronization completed!")
+		},
+	}
+
+	cmd.Flags().IntP("repo-id", "r", 0, "ID of the repository")
+	cmd.MarkFlagRequired("repo-id")
+	cmd.Flags().StringP("signing-key-file", "k", "", "File containing armored GPG private key for signing")
+	cmd.Flags().StringP("signing-key-id", "i", "", "GPG key ID, fingerprint, or email to use with local GPG")
+
+	return cmd
+}
+
+// Signs the release content using a provided GPG key file.
+func signWithKeyFile(keyFilePath, releaseContent string) (*SyncRepositoryRequest, error) {
+	keyFd, err := os.Open(keyFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open key file: %s", err)
+	}
+	defer keyFd.Close()
+
+	key, err := crypto.NewKeyFromReader(keyFd)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse key file: %s", err)
+	}
+	locked, err := key.IsLocked()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine whether key is locked: %s", err)
+	}
+	if locked {
+		fmt.Printf("Key is locked. Please enter passphrase: ")
+		var passphrase []byte
+		passphrase, err = term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return nil, fmt.Errorf("could not read passphrase: %s", err)
+		}
+		key, err = key.Unlock(passphrase)
+		if err != nil {
+			return nil, fmt.Errorf("could not unlock key: %s", err)
+		}
+		fmt.Println()
+	}
+
+	pgp := crypto.PGP()
+	signer, err := pgp.Sign().SigningKey(key).New()
+	if err != nil {
+		return nil, fmt.Errorf("could not create signer: %s", err)
+	}
+
+	// Notice the trimmed newline. This is apparently a long-standing
+	// compatibility bug in GPG cleartext signing. See:
+	// - https://lists.gnupg.org/pipermail/gnupg-devel/1999-September/016016.html
+	// - https://dev.gnupg.org/T7106
+	clearsigned, err := signer.SignCleartext([]byte(strings.TrimSuffix(releaseContent, "\n")))
+	if err != nil {
+		return nil, fmt.Errorf("could not clearsign release index: %s", err)
+	}
+	detached, err := signer.Sign([]byte(releaseContent), crypto.Armor)
+	if err != nil {
+		return nil, fmt.Errorf("could not detached sign release index: %s", err)
+	}
+
+	return &SyncRepositoryRequest{
+		Clearsigned: string(clearsigned),
+		Detached:    string(detached),
+	}, nil
+}
+
+// Signs the release content using the local GPG installation.
+func signWithLocalGPG(keyID, releaseContent string) (*SyncRepositoryRequest, error) {
+	fmt.Println("Using local GPG installation for signing")
+
+	gpgClearsignCmd := exec.Command("gpg", "--clearsign", "--local-user", keyID, "--batch", "--yes")
+	gpgClearsignCmd.Stdin = strings.NewReader(releaseContent)
+	var clearsignedOutput bytes.Buffer
+	gpgClearsignCmd.Stdout = &clearsignedOutput
+	var clearsignedError bytes.Buffer
+	gpgClearsignCmd.Stderr = &clearsignedError
+
+	err := gpgClearsignCmd.Run()
+	if err != nil {
+		errMsg := fmt.Sprintf("could not clearsign release index: %s", err)
+		if clearsignedError.Len() > 0 {
+			errMsg += fmt.Sprintf("\nGPG error output: %s", clearsignedError.String())
+		}
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+	clearsigned := clearsignedOutput.Bytes()
+
+	gpgDetachCmd := exec.Command("gpg", "--detach-sign", "--armor", "--local-user", keyID, "--batch", "--yes")
+	gpgDetachCmd.Stdin = strings.NewReader(releaseContent)
+	var detachedOutput bytes.Buffer
+	gpgDetachCmd.Stdout = &detachedOutput
+	var detachedError bytes.Buffer
+	gpgDetachCmd.Stderr = &detachedError
+
+	err = gpgDetachCmd.Run()
+	if err != nil {
+		errMsg := fmt.Sprintf("could not detached sign release index: %s", err)
+		if detachedError.Len() > 0 {
+			errMsg += fmt.Sprintf("\nGPG error output: %s", detachedError.String())
+		}
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+	detached := detachedOutput.Bytes()
+
+	return &SyncRepositoryRequest{
+		Clearsigned: string(clearsigned),
+		Detached:    string(detached),
+	}, nil
+}


### PR DESCRIPTION
## Rationale

In automated build environments, it might be acceptable to have private signing key material available in file form, so it should be fine to hand over the key to Attune via `--signing-key-file`.

However, in some scenarios, that’s not feasible.  
For example, a senior package developer might be evaluating Attune for their team, and they keep their signing key on a personal YubiKey, so they can’t export their private key material for Attune even if they were willing to (and that’s a big if).

Or a package maintainer might be using GPG agent forwarding, e.g. because they’re running the Attune CLI in a container, or for troubleshooting a multi-architecture build on a remote build node.

## Proposed feature

To support these scenarios, this PR adds a `--signing-key-id` switch to the CLI as an alternative to `--signing-key-file`.

## Note

This feature is meant to be independent from, and unrelated to, HSM support; it is primarily meant to remove hurdles for an individual’s out-of-the-box experience while trying out the community edition, or as the occasional fallback for troubleshooting.
