### PR TITLE
feat: Productionize Dockerfile

### DIFF
--- a/controlplane/Dockerfile
+++ b/controlplane/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86.0-bookworm
+FROM rust:1.86.0-bookworm AS build
 
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo 'fn main() { println!("Placeholder build target")}' > ./src/main.rs
@@ -7,5 +7,14 @@ COPY ./.sqlx ./.sqlx
 COPY ./src ./src
 RUN touch ./src/main.rs && cargo build --release
 
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update
+RUN apt-get install libssl3
+
+COPY --from=build /target/release/attune-server /usr/local/bin/attune-server
+
+USER 1000:1000
+
 ENV RUST_LOG=trace
-ENTRYPOINT ["cargo", "run", "--release", "--bin", "attune-server"]
+ENTRYPOINT ["attune-server"]


### PR DESCRIPTION
1. Run rootlessly.
2. Don't run in the build container.

Tested locally in Docker Compose. Resolves #23.