### PR TITLE
fix: Vanilla docker compose up should work self-hosted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,23 +46,11 @@ services:
     volumes:
       - ./docker/migrate:/app
     working_dir: /app
+    # If you're using IAM authentication with RDS Postgres, you can use
+    # `migrate:rds` instead of `migrate` to get the database password from IMDS:
+    #
+    # command: ["npm", "run", "migrate:rds"]
     command: ["npm", "run", "migrate"]
-    depends_on:
-      postgres:
-        condition: service_healthy
-    networks:
-      - dev
-    restart: on-failure
-  migraterds:
-    build:
-      context: ./docker/migrate
-      dockerfile: Dockerfile
-    environment:
-      - ATTUNE_DATABASE_URL=postgres://attune:attune@postgres:5432/attune
-    volumes:
-      - ./docker/migrate:/app
-    working_dir: /app
-    command: ["npm", "run", "migrate:rds"]
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
FYI @jssblck, I'm reverting a part of #83. We want to make sure `docker compose up` works and does the right thing by default with no other arguments when run on a local laptop, because this is generally how users will first test out a PoC deployment.