### PR TITLE
Retry subcommands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.deb filter=lfs diff=lfs merge=lfs -text

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "md-5 0.10.6",
  "percent-encoding",
  "pgp 0.16.0",
+ "rand 0.9.2",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ lazy-regex = "3.4.1"
 md-5 = "0.10.6"
 percent-encoding = "2.3.1"
 pgp = "0.16.0"
+rand = "0.9.2"
 reqwest = { version = "0.12.22", features = ["json", "multipart"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/packages/attune/Cargo.toml
+++ b/packages/attune/Cargo.toml
@@ -26,6 +26,7 @@ lazy-regex.workspace = true
 md-5.workspace = true
 percent-encoding.workspace = true
 pgp.workspace = true
+rand.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 serde.workspace = true

--- a/packages/attune/src/api/mod.rs
+++ b/packages/attune/src/api/mod.rs
@@ -1,3 +1,4 @@
+use http::StatusCode;
 use percent_encoding::{AsciiSet, CONTROLS};
 
 pub mod auth;
@@ -19,3 +20,29 @@ pub const PATH_SEGMENT_PERCENT_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b'}')
     .add(b'/')
     .add(b'%');
+
+/// Translate a PSQL error into the server's canonical error response
+/// based on the error code.
+pub fn translate_psql_error(error: sqlx::Error) -> ErrorResponse {
+    tracing::error!(?error, "sqlx error");
+    if let Some(database_error) = error.as_database_error()
+        && let Some(code) = database_error.code()
+    {
+        match &*code {
+            "40001" => {
+                return ErrorResponse::builder()
+                    .status(StatusCode::CONFLICT)
+                    .error("CONCURRENT_INDEX_CHANGE")
+                    .message("concurrent index change")
+                    .build();
+            }
+            _ => {}
+        }
+    }
+
+    ErrorResponse::builder()
+        .status(StatusCode::CONFLICT)
+        .error("DATABASE_ERROR")
+        .message(format!("internal database error: {error}"))
+        .build()
+}

--- a/packages/attune/src/api/mod.rs
+++ b/packages/attune/src/api/mod.rs
@@ -28,15 +28,14 @@ pub fn translate_psql_error(error: sqlx::Error) -> ErrorResponse {
     if let Some(database_error) = error.as_database_error()
         && let Some(code) = database_error.code()
     {
-        match &*code {
-            "40001" => {
-                return ErrorResponse::builder()
-                    .status(StatusCode::CONFLICT)
-                    .error("CONCURRENT_INDEX_CHANGE")
-                    .message("concurrent index change")
-                    .build();
-            }
-            _ => {}
+        // As we encounter other error codes, add them here.
+        // 40001: https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
+        if code == "40001" {
+            return ErrorResponse::builder()
+                .status(StatusCode::CONFLICT)
+                .error("CONCURRENT_INDEX_CHANGE")
+                .message("concurrent index change")
+                .build();
         }
     }
 

--- a/packages/attune/src/api/mod.rs
+++ b/packages/attune/src/api/mod.rs
@@ -25,17 +25,17 @@ pub const PATH_SEGMENT_PERCENT_ENCODE_SET: &AsciiSet = &CONTROLS
 /// based on the error code.
 pub fn translate_psql_error(error: sqlx::Error) -> ErrorResponse {
     tracing::error!(?error, "sqlx error");
-    if let Some(database_error) = error.as_database_error()
-        && let Some(code) = database_error.code()
-    {
-        // As we encounter other error codes, add them here.
-        // 40001: https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
-        if code == "40001" {
-            return ErrorResponse::builder()
-                .status(StatusCode::CONFLICT)
-                .error("CONCURRENT_INDEX_CHANGE")
-                .message("concurrent index change")
-                .build();
+    if let Some(database_error) = error.as_database_error() {
+        if let Some(code) = database_error.code() {
+            // As we encounter other error codes, add them here.
+            // 40001: https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
+            if code == "40001" {
+                return ErrorResponse::builder()
+                    .status(StatusCode::CONFLICT)
+                    .error("CONCURRENT_INDEX_CHANGE")
+                    .message("concurrent index change")
+                    .build();
+            }
         }
     }
 

--- a/packages/attune/src/bin/attune/main.rs
+++ b/packages/attune/src/bin/attune/main.rs
@@ -104,6 +104,9 @@ async fn main() -> ExitCode {
     }
 
     // Execute subcommand.
+    //
+    // TODO: We should update all the subcommands to return `Result<String, ErrorResponse>`
+    //       so that we can centralize retries, pretty printing, etc.
     match args.tool {
         ToolCommand::Apt(command) => cmd::apt::handle_apt(ctx, command).await,
     }

--- a/packages/attune/src/server/repo/index/sign.rs
+++ b/packages/attune/src/server/repo/index/sign.rs
@@ -657,14 +657,7 @@ pub async fn handler(
     //
     // We've added logging here so that we can see the actual error code
     // and special case it in the future.
-    if let Err(error) = tx.commit().await {
-        tracing::error!(?error, "transaction commit failed");
-        return Err(ErrorResponse::builder()
-            .status(StatusCode::CONFLICT)
-            .error("CONCURRENT_INDEX_CHANGE")
-            .message("concurrent index change")
-            .build());
-    }
+    tx.commit().await.map_err(translate_psql_error)?;
 
     // Save the new index state to S3. This must occur after the transaction
     // commits so that we are sure that we are not incorrectly overwriting a

--- a/scripts/concurrent_add.sh
+++ b/scripts/concurrent_add.sh
@@ -15,7 +15,7 @@ if [[ ! -d "fixtures" ]]; then
     exit 1
 fi
 
-cargo run --bin attune -- apt repo create testing-concurrent
+cargo run --bin attune -- apt repo create testing-concurrent || true
 
 # Find all .deb files in ~/scratch
 deb_files=("fixtures"/*.deb)

--- a/scripts/concurrent_add.sh
+++ b/scripts/concurrent_add.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Check if ATTUNE_GPG_KEY_ID is set
+if [[ -z "$ATTUNE_GPG_KEY_ID" ]]; then
+    echo "Error: ATTUNE_GPG_KEY_ID environment variable is not set"
+    exit 1
+fi
+
+# Check if fixtures directory exists
+if [[ ! -d "fixtures" ]]; then
+    echo "Error: fixtures directory does not exist"
+    exit 1
+fi
+
+cargo run --bin attune -- apt repo create testing-concurrent
+
+# Find all .deb files in ~/scratch
+deb_files=("fixtures"/*.deb)
+
+# Check if any .deb files exist
+if [[ ! -e "${deb_files[0]}" ]]; then
+    echo "No .deb files found in fixtures"
+    exit 1
+fi
+
+echo "Found ${#deb_files[@]} .deb files in fixtures"
+echo "Adding packages concurrently..."
+
+# Array to store background process PIDs
+pids=()
+
+# Launch concurrent jobs
+for deb_file in "${deb_files[@]}"; do
+    echo "Starting: $(basename "$deb_file")"
+    cargo run --bin attune -- apt pkg add -r testing-concurrent -d testing -c testing -k "$ATTUNE_GPG_KEY_ID" "$deb_file" &
+    pids+=($!)
+done
+
+echo "Launched ${#pids[@]} concurrent processes"
+echo "Waiting for completion..."
+
+# Wait for all background processes and collect results
+failed=0
+for i in "${!pids[@]}"; do
+    pid=${pids[$i]}
+    deb_file=${deb_files[$i]}
+
+    if wait $pid; then
+        echo "✓ Success: $(basename "$deb_file")"
+    else
+        echo "✗ Failed: $(basename "$deb_file")"
+        ((failed++))
+    fi
+done
+
+echo "Completed: $((${#pids[@]} - failed)) succeeded, $failed failed"
+
+if [[ $failed -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/fixtures/attune-test-package_2.0.0_linux_amd64.deb
+++ b/scripts/fixtures/attune-test-package_2.0.0_linux_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cc31c4aff9793961f9cede87f01d8d8c205f75adc6fab62513cd06f354d36a2
+size 692288

--- a/scripts/fixtures/attune-test-package_2.0.0_linux_arm64.deb
+++ b/scripts/fixtures/attune-test-package_2.0.0_linux_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0108911c4a1f991ce2a258c0ba5eebecf07b22b6a49e41ac3378addc39bdd7eb
+size 651070

--- a/scripts/fixtures/attune-test-package_3.0.5_linux_amd64.deb
+++ b/scripts/fixtures/attune-test-package_3.0.5_linux_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8a9a6162fd5e6a93d032e132571c6abb45191196e5f28583cf69392677e981a
+size 692294

--- a/scripts/fixtures/attune-test-package_3.0.5_linux_arm64.deb
+++ b/scripts/fixtures/attune-test-package_3.0.5_linux_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70151415614b7f90bd1612cd700f2b532cb975e287f33d0f003ddd0eb541ab36
+size 651154

--- a/scripts/fixtures/cod-test-package_3.0.5_linux_amd64.deb
+++ b/scripts/fixtures/cod-test-package_3.0.5_linux_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcce8ba7aeaea0a3a1c402b1e336aa0472dc3264164f86005422161fda3f9779
+size 692348

--- a/scripts/fixtures/cod-test-package_3.0.5_linux_arm64.deb
+++ b/scripts/fixtures/cod-test-package_3.0.5_linux_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0b56b09f06a75388539bf0d0e9cf3b1e3658148de48128909e7ef67147151c3
+size 651078

--- a/scripts/fixtures/salmon-test-package_3.0.5_linux_amd64.deb
+++ b/scripts/fixtures/salmon-test-package_3.0.5_linux_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f22b90a2c76089848e4ecdcac45ec6513f9529553cd491199e3ae0a49335810
+size 692310

--- a/scripts/fixtures/salmon-test-package_3.0.5_linux_arm64.deb
+++ b/scripts/fixtures/salmon-test-package_3.0.5_linux_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ba8c289806f9e10655e6f0f69f45ab7219823fd0374faa6c9157539cb201c0e
+size 651190

--- a/scripts/fixtures/tuna-test-package_3.0.5_linux_amd64.deb
+++ b/scripts/fixtures/tuna-test-package_3.0.5_linux_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ef9d599732513edd722798ade29224888a330f057f35cb9b7f1b120efd3e9d4
+size 692330

--- a/scripts/fixtures/tuna-test-package_3.0.5_linux_arm64.deb
+++ b/scripts/fixtures/tuna-test-package_3.0.5_linux_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ac80e2d32b4e39f66dc3759d25bbc4173177b8d57ba7b1ff7f5f87de287fdf3
+size 651158

--- a/scripts/serial_add.sh
+++ b/scripts/serial_add.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Check if ATTUNE_GPG_KEY_ID is set
+if [[ -z "$ATTUNE_GPG_KEY_ID" ]]; then
+    echo "Error: ATTUNE_GPG_KEY_ID environment variable is not set"
+    exit 1
+fi
+
+# Check if fixtures directory exists
+if [[ ! -d "fixtures" ]]; then
+    echo "Error: fixtures directory does not exist"
+    exit 1
+fi
+
+# Find all .deb files in fixtures
+deb_files=("fixtures"/*.deb)
+
+# Check if any .deb files exist
+if [[ ! -e "${deb_files[0]}" ]]; then
+    echo "No .deb files found in fixtures"
+    exit 1
+fi
+
+echo "Found ${#deb_files[@]} .deb files in fixtures"
+echo "Adding packages serially..."
+
+# Process files one by one
+failed=0
+for deb_file in "${deb_files[@]}"; do
+    echo "Processing: $(basename "$deb_file")"
+
+    if cargo run --bin attune -- apt pkg add -r testing-serial -d jammy -c testing -k "$ATTUNE_GPG_KEY_ID" "$deb_file"; then
+        echo "✓ Success: $(basename "$deb_file")"
+    else
+        echo "✗ Failed: $(basename "$deb_file")"
+        ((failed++))
+    fi
+done
+
+echo "Completed: $((${#deb_files[@]} - failed)) succeeded, $failed failed"
+
+if [[ $failed -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/serial_add.sh
+++ b/scripts/serial_add.sh
@@ -15,6 +15,8 @@ if [[ ! -d "fixtures" ]]; then
     exit 1
 fi
 
+cargo run --bin attune -- apt repo create testing-serial || true
+
 # Find all .deb files in fixtures
 deb_files=("fixtures"/*.deb)
 


### PR DESCRIPTION
Resolves #84 

- Adds retries for `pkg {add|rm}` subcommands.
- Adds server-side functionality to signal conflicts to the client.

This PR scope is quite focused on this ticket: we don't add generalized retries and we don't focus on other SQL errors checking.

Tested using the scripts in this PR a few times; these all passed locally.