### PR TITLE
ci: Build Docker Compose images

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,17 +36,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image to test
-        id: docker-build
+      - name: Build Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/attune/Dockerfile
           push: false
-          tags: local-test
-          labels: local-test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build Docker Compose development images
+        run: docker compose build
 
   rust:
     name: Build, check, and test Rust


### PR DESCRIPTION
This updates our CI pipeline to build _every_ Docker Compose image, to make sure that all the images still build. This isn't _quite_ what I want yet. Ideally, we would also run a smoke test against a `docker compose up` setup. But this still provides plenty of value.