### PR TITLE
Add `attune` deb generation to tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -205,8 +205,8 @@ jobs:
         run: |
           mkdir -p /tmp/release
           cp target/release/attune /tmp/release/attune-${{ env.RELEASE_NAME }}_${{ runner.os }}-${{ runner.arch }}
-          cp /tmp/macos-binary/attune /tmp/release/attune-${{ env.RELEASE_NAME }}_macOS-ARM64
-          cp target/release/attune-server /tmp/release/attune-server-${{ env.RELEASE_NAME }}_${{ runner.os }}-${{ runner.arch }}
+          cp /tmp/macos-binary/attune /tmp/release/attune-${{ env.RELEASE_NAME }}_macOS-arm64
+          cp target/release/attune-server /tmp/release/attune-controlplane-${{ env.RELEASE_NAME }}_${{ runner.os }}-${{ runner.arch }}
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -193,6 +193,14 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-targets --all-features --release
 
+      # Install cargo-deb for .deb package generation.
+      - name: Install cargo-deb
+        run: cargo install cargo-deb
+
+      # Generate .deb package for attune CLI.
+      - name: Build .deb package
+        run: cargo deb -p attune
+
       # Download notarized macOS binary
       - name: Download notarized macOS binary
         uses: actions/download-artifact@v4
@@ -207,6 +215,7 @@ jobs:
           cp target/release/attune /tmp/release/attune-${{ env.RELEASE_NAME }}_${{ runner.os }}-${{ runner.arch }}
           cp /tmp/macos-binary/attune /tmp/release/attune-${{ env.RELEASE_NAME }}_macOS-arm64
           cp target/release/attune-server /tmp/release/attune-controlplane-${{ env.RELEASE_NAME }}_${{ runner.os }}-${{ runner.arch }}
+          cp target/debian/attune_*.deb /tmp/release/attune-${{ env.RELEASE_NAME }}.deb
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v2

--- a/packages/attune/Cargo.toml
+++ b/packages/attune/Cargo.toml
@@ -66,3 +66,18 @@ testcontainers.workspace = true
 tokio-util.workspace = true
 workspace_root.workspace = true
 xshell.workspace = true
+
+[package.metadata.deb]
+maintainer = "Attune Technologies, Inc. <team@attunehq.com>"
+copyright = "2025, Attune Technologies, Inc. <team@attunehq.com>"
+license-file = ["../../LICENSE", "0"]
+extended-description = "Attune CLI"
+homepage = "https://www.attunehq.com/"
+repository = "https://github.com/attunehq/attune"
+depends = "$auto, libgpgme11"
+section = "utility"
+priority = "optional"
+assets = [
+    ["target/release/attune", "usr/bin/", "755"],
+    ["../../README.md", "usr/share/doc/attune/README", "644"],
+]

--- a/packages/attune/Cargo.toml
+++ b/packages/attune/Cargo.toml
@@ -71,14 +71,5 @@ test-with = "0.15.4"
 [package.metadata.deb]
 maintainer = "Attune Technologies, Inc. <team@attunehq.com>"
 copyright = "2025, Attune Technologies, Inc. <team@attunehq.com>"
-license-file = ["../../LICENSE", "0"]
-extended-description = "Attune CLI"
-homepage = "https://www.attunehq.com/"
-repository = "https://github.com/attunehq/attune"
 depends = "$auto, libgpgme11"
-section = "utility"
 priority = "optional"
-assets = [
-    ["target/release/attune", "usr/bin/", "755"],
-    ["../../README.md", "usr/share/doc/attune/README", "644"],
-]


### PR DESCRIPTION
By creating a deb, we make it easier for users to install attune along with necessary dependencies (namely, libgpgme11).