### PR TITLE
refactor: Factor out migration `npm run` into `ENTRYPOINT`

### DIFF
--- a/docker/migrate/Dockerfile
+++ b/docker/migrate/Dockerfile
@@ -6,4 +6,5 @@ RUN npm install
 
 COPY . .
 RUN npm run build
-CMD ["npm", "run", "migrate"]
+ENTRYPOINT ["npm", "run"]
+CMD ["migrate"]


### PR DESCRIPTION
This makes it a little easier for users to override the NPM script (e.g. to use `migrate:rds` instead of `migrate`).