### PR TITLE
fix: Correct macOS asset filename case in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           formula-path: Formula/attune.rb
           homebrew-tap: attunehq/homebrew-attune
           download-url: |
-            https://github.com/attunehq/attune/releases/download/v${{ steps.version.outputs.version }}/attune-v${{ steps.version.outputs.version }}_macOS-ARM64
+            https://github.com/attunehq/attune/releases/download/v${{ steps.version.outputs.version }}/attune-v${{ steps.version.outputs.version }}_macOS-arm64
           commit-message: |
             Update attune to v${{ steps.version.outputs.version }}
             


### PR DESCRIPTION
## Summary
- Fixes the Homebrew formula update workflow failing due to asset name case mismatch
- The workflow expected `macOS-ARM64` but the actual release asset is `macOS-arm64`

## Test plan
- [ ] Re-run the failed release workflow after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)