### PR TITLE
fix: Run Homebrew formula verification on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
+  verify-homebrew:
+    runs-on: macos-latest
+    needs: update-homebrew
+    steps:
       - name: Verify formula syntax
         run: |
           brew tap attunehq/attune


### PR DESCRIPTION
## Summary
- Splits the Homebrew formula verification into a separate job that runs on macOS
- The `brew` command is not available on Ubuntu runners, causing the verify step to fail

## Test plan
- [ ] Merge and verify on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)