### PR TITLE
chore: Update EE submodule and add backon workspace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sigv4",
  "axum",
+ "backon",
  "clap",
  "colored",
  "debian-packaging",
@@ -1132,6 +1133,17 @@ dependencies = [
  "tower",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ aws-sdk-s3 = "1.82.0"
 aws-sigv4 = "1.3.3"
 axum = { version = "0.8.3", features = ["macros", "multipart"] }
 axum-test = { version = "17.3.0", features = ["all"] }
+backon = "1.6.0"
 base64 = "0.22.1"
 bollard = "0.19.1"
 bon = "3.6.5"


### PR DESCRIPTION
## Summary
- Updates attune-ee submodule to latest main
- Adds `backon` as a workspace dependency (v1.6.0) for future unification

## Test plan
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)